### PR TITLE
feat(translations): Add pt-BR localization strings

### DIFF
--- a/DevToys/DevToys/Resource/pt-BR.lproj/Localizable.strings
+++ b/DevToys/DevToys/Resource/pt-BR.lproj/Localizable.strings
@@ -170,8 +170,8 @@
 "Generate PDF" = "Gerar PDF";
 "Page" = "Página";
 
-"tool.imageconvert.title" = "Conversor de Image";
-"tool.imageconvert.mintitle" = "Conversor de Image";
+"tool.imageconvert.title" = "Conversor de Imagem";
+"tool.imageconvert.mintitle" = "Conversor de Imagem";
 "tool.imageconvert.description" = "Converte ou redimensiona imagens";
 "PNG Format" = "Formato PNG";
 "JPEG Format" = "Formato JPEG";

--- a/DevToys/DevToys/Resource/pt-BR.lproj/Localizable.strings
+++ b/DevToys/DevToys/Resource/pt-BR.lproj/Localizable.strings
@@ -116,7 +116,7 @@
 "tool.hashgen.description" = "Calcula hashes MD5, SHA1, SHA256 e SHA 512 a partir de um texto";
 
 "tool.uuidgen.title" = "Gerador de UUID";
-"tool.uuidgen.mintitle" = "Hash";
+"tool.uuidgen.mintitle" = "UUID";
 "tool.uuidgen.description" = "Gera UUIDs";
 "Generate UUIDs" = "Gerar UUIDs";
 

--- a/DevToys/DevToys/Resource/pt-BR.lproj/Localizable.strings
+++ b/DevToys/DevToys/Resource/pt-BR.lproj/Localizable.strings
@@ -1,0 +1,186 @@
+/*
+  Localizable.strings
+  DevToys
+
+  Created by daniel bertoldi on 2022/02/14.
+  
+*/
+
+// - General -
+"Configuration" = "Configuração";
+"Format" = "Formatar";
+"Pretty" = "Embelezar";
+"Minified" = "Minificar";
+"Encoded" = "Codificar";
+"Decoded" = "Decodificar";
+"File" = "Arquivo";
+"Text" = "Texto";
+"Copy" = "Copiar";
+"Paste" = "Colar";
+"Copied!" = "Copiado!";
+"Pasted!" = "Colado";
+"Open" = "Abrir";
+"Export" = "Exportar";
+"Import" = "Importar";
+"Input" = "Entrada";
+"Output" = "Saída";
+"No selection" = "Sem seleção";
+"Drop Files Here" = "Arraste Os Arquivos Aqui";
+"Untitled Tool" = "Ferramenta Sem Nome";
+"Uppercase" = "Maíusculo";
+"Hyphens" = "Hífens";
+"Type" = "Tipo";
+"Length" = "Comprimento";
+"Convert" = "Converter";
+"Information" = "Informação";
+"Clear" = "Limpar";
+"Delete" = "Deletar";
+
+// - Category -
+"category.home" = "Menu Principal";
+"category.converters" = "Conversores";
+"category.encoders_decoders" = "Codificadores / Decodificadores";
+"category.formatters" = "Formatadores";
+"category.generators" = "Geradores";
+"category.text" = "Texto";
+"category.graphic" = "Gráficos";
+
+// - Tool -
+"tool.home.title" = "Menu Principal";
+"tool.home.mintitle" = "Menu Principal";
+"tool.home.description" = "Procure por ferramentas aqui.";
+
+"tool.jsonyaml.title" = "Conversor JSON <> Yaml";
+"tool.jsonyaml.mintitle" = "JSON <> Yaml";
+"tool.jsonyaml.description" = "Converta dados em JSON para YAML e vice-versa";
+
+"tool.numbase.title" = "Conversor de Base Numérica";
+"tool.numbase.mintitle" = "Base Numérica";
+"tool.numbase.description" = "Converta números de uma base para outra";
+"Format Number" = "Formatar Número";
+"Decimal" = "Decimal";
+"Hexdecimal" = "Hexadecimal";
+"Octal" = "Octal";
+"Binary" = "Binário";
+
+"tool.date.title" = "Conversor de Data";
+"tool.date.mintitle" = "Data";
+"tool.date.description" = "Converte um formato de data para outro";
+"Now" = "Agora";
+"Date" = "Data";
+"Unix Time" = "Tempo Unix";
+"ISO 8601" = "ISO 8601";
+"Calender" = "Calendário";
+
+"tool.html.title" = "Codificador / Decodificador de HTML";
+"tool.html.mintitle" = "HTML";
+"tool.html.description" = "Codifica ou decodifica todos os caracteres aplicáveis ao seu HTML correspondente";
+
+"tool.url.title" = "Codificador / Decodificador de URL";
+"tool.url.mintitle" = "URL";
+"tool.url.description" = "Codifica ou decodifica todos os caracteres aplicáveis ao seu URL correspondente";
+
+"tool.base64.title" = "Codificador / Decodificador de Base64";
+"tool.base64.mintitle" = "Base64";
+"tool.base64.description" = "Codifica e decodifica dados em Base64";
+"Source Type" = "Tipo de Fonte";
+"Text Source" = "Fonte de Texto";
+"File Source" = "Fonte de Arquivo";
+
+"tool.jwt.title" = "Codificador / Decodificador de JWT";
+"tool.jwt.mintitle" = "JWT";
+"tool.jwt.description" = "Decodifica um payload e assinatura de um header JWT";
+"JWT Token" = "Token JWT";
+"Header" = "Header";
+"Payload" = "Payload";
+
+"tool.jsonformat.title" = "Formatador de JSON";
+"tool.jsonformat.mintitle" = "JSON";
+"tool.jsonformat.description" = "Indenta ou minifica um JSON";
+"Indentation" = "Indentação";
+"2 Spaces" = "2 Espaços";
+"4 Spaces" = "4 Espaços";
+"1 Tab" = "1 Tab";
+
+"tool.xmlformat.title" = "Formatador XML";
+"tool.xmlformat.mintitle" = "XML";
+"tool.xmlformat.description" = "Indenta ou minifica um XML";
+"HTML Document" = "Documento HTML";
+"XML Document" = "Documento XML";
+"Document Type" = "Tipo de Documento";
+"Auto Fix Document" = "Corrigir Documento Automaticamente";
+"Pretty Document" = "Embelezar Documento";
+
+"tool.hashgen.title" = "Gerador de Hash";
+"tool.hashgen.mintitle" = "Hash";
+"tool.hashgen.description" = "Calcula hashes MD5, SHA1, SHA256 e SHA 512 a partir de um texto";
+
+"tool.uuidgen.title" = "Gerador de UUID";
+"tool.uuidgen.mintitle" = "Hash";
+"tool.uuidgen.description" = "Gera UUIDs";
+"Generate UUIDs" = "Gerar UUIDs";
+
+"tool.ligen.title" = "Gerador de Lorem Ipsum";
+"tool.ligen.mintitle" = "Lorem Ipsum";
+"tool.ligen.description" = "Gera texto de Lorem Ipsum";
+"Type of generating Lorem Ipsum" = "Tipo de  geração de Lorem Ipsum";
+"Length of generating Lorem Ipsum" = "Tamanho do Lorem Ipsum a ser gerado";
+"Words" = "Palavras";
+"Sentences" = "Frases";
+"Paragraphs" = "Parágrafos";
+
+"tool.checksum.title" = "Gerador de Checksum";
+"tool.checksum.mintitle" = "Checksum";
+"tool.checksum.description" = "Gera ou testa o checksum de um arquivo";
+"Output Comparer" = "Comparador de Saída";
+"Hash Algorithm" = "Algoritmo de Hash";
+"Select which algorithm you want to use" = "Selecione qual algoritmo você quer usar";
+
+"tool.textinspect.title" = "Inspetor de Texto e Conversor de Case";
+"tool.textinspect.mintitle" = "Inspetor de Texto e Conversor de Case";
+"tool.textinspect.description" = " Analisa o texto e converte para um case diferente";
+"Charactors" = "Caracteres";
+"Words" = "Palavras";
+"Lines" = "Linhas";
+"Bytes" = "Bytes";
+
+"tool.regex.title" = "Testador de Regex";
+"tool.regex.mintitle" = "Regex";
+"tool.regex.description" = "Testar expressão regular";
+"Reguler expression" = "Expressão Regular";
+
+"tool.hyphenremove.title" = "Removedor de Hifenação";
+"tool.hyphenremove.mintitle" = "Hifenação";
+"tool.hyphenremove.description" = "Remove hifenações copiados de um texto PDF";
+
+"tool.imageoptim.title" = "Compressor de PNG / JPEG";
+"tool.imageoptim.mintitle" = "Compressor de PNG / JPEG";
+"tool.imageoptim.description" = "Otimizador sem perdas de PNG e JPEG";
+"Optimize Level" = "Nível de Otimização";
+"Low" = "Baixo";
+"Medium" = "Médio";
+"High" = "Alto";
+"Very High (Slow)" = "Muito Alto (Lento)";
+
+"tool.pdfgen.title" = "Gerador de PDF";
+"tool.pdfgen.mintitle" = "Gerador de PDF";
+"tool.pdfgen.description" = "Gera PDF a partir de múltipas imagens";
+"Images" = "Imagens";
+"Size" = "Tamanho";
+"Generate PDF" = "Gerar PDF";
+"Page" = "Página";
+
+"tool.imageconvert.title" = "Conversor de Image";
+"tool.imageconvert.mintitle" = "Conversor de Image";
+"tool.imageconvert.description" = "Converte ou redimensiona imagens";
+"PNG Format" = "Formato PNG";
+"JPEG Format" = "Formato JPEG";
+"TIFF Format" = "Formato TIFF";
+"GIF Format" = "Formato GIF";
+"Scale to Fill" = "Escalar para preencher";
+"Scale to Fit" = "Escalar para encaixar";
+"Image Format" = "Formatar Imagem";
+"Resize" = "Redimensionar";
+"Converted Images" = "Imagens Convertidas";
+"Scale" = "Escalar";
+"Size" = "Tamanho";

--- a/DevToys/DevToys/Resource/pt-BR.lproj/Main.strings
+++ b/DevToys/DevToys/Resource/pt-BR.lproj/Main.strings
@@ -1,0 +1,396 @@
+
+/* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "1UK-8n-QPP"; */
+"1UK-8n-QPP.title" = "Customizar Barra de Ferramentas…";
+
+/* Class = "NSMenuItem"; title = "DevToys"; ObjectID = "1Xt-HY-uBw"; */
+"1Xt-HY-uBw.title" = "DevToys";
+
+/* Class = "NSMenu"; title = "Find"; ObjectID = "1b7-l0-nxx"; */
+"1b7-l0-nxx.title" = "Procurar";
+
+/* Class = "NSMenuItem"; title = "Lower"; ObjectID = "1tx-W0-xDw"; */
+"1tx-W0-xDw.title" = "Diminuir";
+
+/* Class = "NSMenuItem"; title = "Raise"; ObjectID = "2h7-ER-AoG"; */
+"2h7-ER-AoG.title" = "Aumentar";
+
+/* Class = "NSMenuItem"; title = "Transformations"; ObjectID = "2oI-Rn-ZJC"; */
+"2oI-Rn-ZJC.title" = "Transformações";
+
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "3IN-sU-3Bg"; */
+"3IN-sU-3Bg.title" = "Ortografia";
+
+/* Class = "NSMenuItem"; title = "Use Default"; ObjectID = "3Om-Ey-2VK"; */
+"3Om-Ey-2VK.title" = "Usar Padrão";
+
+/* Class = "NSMenu"; title = "Speech"; ObjectID = "3rS-ZA-NoH"; */
+"3rS-ZA-NoH.title" = "Fala";
+
+/* Class = "NSMenuItem"; title = "Tighten"; ObjectID = "46P-cB-AYj"; */
+"46P-cB-AYj.title" = "Apertar";
+
+/* Class = "NSMenuItem"; title = "Find"; ObjectID = "4EN-yA-p0u"; */
+"4EN-yA-p0u.title" = "Procurar";
+
+/* Class = "NSMenuItem"; title = "Enter Full Screen"; ObjectID = "4J7-dP-txa"; */
+"4J7-dP-txa.title" = "Entrar em Tela Cheia";
+
+/* Class = "NSMenuItem"; title = "Quit DevToys"; ObjectID = "4sb-4s-VLi"; */
+"4sb-4s-VLi.title" = "Sair do DevToys";
+
+/* Class = "NSMenuItem"; title = "Edit"; ObjectID = "5QF-Oa-p0T"; */
+"5QF-Oa-p0T.title" = "Editar";
+
+/* Class = "NSMenuItem"; title = "Copy Style"; ObjectID = "5Vv-lz-BsD"; */
+"5Vv-lz-BsD.title" = "Copiar Estilo";
+
+/* Class = "NSMenuItem"; title = "About DevToys"; ObjectID = "5kV-Vb-QxS"; */
+"5kV-Vb-QxS.title" = "Sobre o DevToys";
+
+/* Class = "NSMenuItem"; title = "Redo"; ObjectID = "6dh-zS-Vam"; */
+"6dh-zS-Vam.title" = "Refazer";
+
+/* Class = "NSMenuItem"; title = "Correct Spelling Automatically"; ObjectID = "78Y-hA-62v"; */
+"78Y-hA-62v.title" = "Corrigir Ortografia Automaticamente";
+
+/* Class = "NSMenu"; title = "Writing Direction"; ObjectID = "8mr-sm-Yjd"; */
+"8mr-sm-Yjd.title" = "Direção de Escrita";
+
+/* Class = "NSMenuItem"; title = "Substitutions"; ObjectID = "9ic-FL-obx"; */
+"9ic-FL-obx.title" = "Substituições";
+
+/* Class = "NSMenuItem"; title = "Smart Copy/Paste"; ObjectID = "9yt-4B-nSM"; */
+"9yt-4B-nSM.title" = "Copiar/Colar Inteligente";
+
+/* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
+"AYu-sK-qS6.title" = "Menu Principal";
+
+/* Class = "NSMenuItem"; title = "Preferences…"; ObjectID = "BOF-NM-1cW"; */
+"BOF-NM-1cW.title" = "Preferências";
+
+/* Class = "NSMenuItem"; title = "\tLeft to Right"; ObjectID = "BgM-ve-c93"; */
+"BgM-ve-c93.title" = "\tEsquerda para Direita";
+
+/* Class = "NSMenuItem"; title = "Save As…"; ObjectID = "Bw7-FT-i3A"; */
+"Bw7-FT-i3A.title" = "Salvar Como...";
+
+/* Class = "NSMenuItem"; title = "Close"; ObjectID = "DVo-aG-piG"; */
+"DVo-aG-piG.title" = "Fechar";
+
+/* Class = "NSMenuItem"; title = "Spelling and Grammar"; ObjectID = "Dv1-io-Yv7"; */
+"Dv1-io-Yv7.title" = "Ortografia e Gramática";
+
+/* Class = "NSMenu"; title = "Help"; ObjectID = "F2S-fz-NVQ"; */
+"F2S-fz-NVQ.title" = "Ajuda";
+
+/* Class = "NSMenuItem"; title = "DevToys Help"; ObjectID = "FKE-Sm-Kum"; */
+"FKE-Sm-Kum.title" = "Ajuda do DevToys";
+
+/* Class = "NSMenuItem"; title = "Text"; ObjectID = "Fal-I4-PZk"; */
+"Fal-I4-PZk.title" = "Texto";
+
+/* Class = "NSMenu"; title = "Substitutions"; ObjectID = "FeM-D8-WVr"; */
+"FeM-D8-WVr.title" = "Substituições";
+
+/* Class = "NSMenuItem"; title = "Bold"; ObjectID = "GB9-OM-e27"; */
+"GB9-OM-e27.title" = "Negrito";
+
+/* Class = "NSMenu"; title = "Format"; ObjectID = "GEO-Iw-cKr"; */
+"GEO-Iw-cKr.title" = "Formatar";
+
+/* Class = "NSMenuItem"; title = "Use Default"; ObjectID = "GUa-eO-cwY"; */
+"GUa-eO-cwY.title" = "Usar Padrão";
+
+/* Class = "NSMenuItem"; title = "Font"; ObjectID = "Gi5-1S-RQB"; */
+"Gi5-1S-RQB.title" = "Fonte";
+
+/* Class = "NSMenuItem"; title = "Writing Direction"; ObjectID = "H1b-Si-o9J"; */
+"H1b-Si-o9J.title" = "Direção de Escrita";
+
+/* Class = "NSMenuItem"; title = "View"; ObjectID = "H8h-7b-M4v"; */
+"H8h-7b-M4v.title" = "Exibir";
+
+/* Class = "NSMenuItem"; title = "Text Replacement"; ObjectID = "HFQ-gK-NFA"; */
+"HFQ-gK-NFA.title" = "Substituir Texto";
+
+/* Class = "NSMenuItem"; title = "Show Spelling and Grammar"; ObjectID = "HFo-cy-zxI"; */
+"HFo-cy-zxI.title" = "Mostrar Ortografia e Gramática";
+
+/* Class = "NSMenu"; title = "View"; ObjectID = "HyV-fh-RgO"; */
+"HyV-fh-RgO.title" = "Exibir";
+
+/* Class = "NSMenuItem"; title = "Subscript"; ObjectID = "I0S-gh-46l"; */
+"I0S-gh-46l.title" = "Subscrito";
+
+/* Class = "NSMenuItem"; title = "Open…"; ObjectID = "IAo-SY-fd9"; */
+"IAo-SY-fd9.title" = "Abrir...";
+
+/* Class = "NSWindow"; title = "DevToys"; ObjectID = "IQv-IB-iLA"; */
+"IQv-IB-iLA.title" = "DevToys";
+
+/* Class = "NSMenuItem"; title = "Justify"; ObjectID = "J5U-5w-g23"; */
+"J5U-5w-g23.title" = "Justificar";
+
+/* Class = "NSMenuItem"; title = "Use None"; ObjectID = "J7y-lM-qPV"; */
+"J7y-lM-qPV.title" = "Não Usar Nenhum";
+
+/* Class = "NSMenuItem"; title = "Revert to Saved"; ObjectID = "KaW-ft-85H"; */
+"KaW-ft-85H.title" = "Reverter Para Salvo";
+
+/* Class = "NSMenuItem"; title = "Show All"; ObjectID = "Kd2-mp-pUS"; */
+"Kd2-mp-pUS.title" = "Mostrar Tudo";
+
+/* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "LE2-aR-0XJ"; */
+"LE2-aR-0XJ.title" = "Trazer Para Frente";
+
+/* Class = "NSMenuItem"; title = "Paste Ruler"; ObjectID = "LVM-kO-fVI"; */
+"LVM-kO-fVI.title" = "Colar Régua";
+
+/* Class = "NSMenuItem"; title = "\tLeft to Right"; ObjectID = "Lbh-J2-qVU"; */
+"Lbh-J2-qVU.title" = "\tEsquerda Para Direita";
+
+/* Class = "NSMenuItem"; title = "Copy Ruler"; ObjectID = "MkV-Pr-PK5"; */
+"MkV-Pr-PK5.title" = "Copiar Régua";
+
+/* Class = "NSMenuItem"; title = "Services"; ObjectID = "NMo-om-nkz"; */
+"NMo-om-nkz.title" = "Serviços";
+
+/* Class = "NSMenuItem"; title = "\tDefault"; ObjectID = "Nop-cj-93Q"; */
+"Nop-cj-93Q.title" = "\tPadrão";
+
+/* Class = "NSMenuItem"; title = "Minimize"; ObjectID = "OY7-WF-poV"; */
+"OY7-WF-poV.title" = "Minimizar";
+
+/* Class = "NSMenuItem"; title = "Baseline"; ObjectID = "OaQ-X3-Vso"; */
+"OaQ-X3-Vso.title" = "Linha De Base";
+
+/* Class = "NSMenuItem"; title = "Hide DevToys"; ObjectID = "Olw-nP-bQN"; */
+"Olw-nP-bQN.title" = "Esconder DevToys";
+
+/* Class = "NSMenuItem"; title = "Find Previous"; ObjectID = "OwM-mh-QMV"; */
+"OwM-mh-QMV.title" = "Encontrar Anterior";
+
+/* Class = "NSMenuItem"; title = "Stop Speaking"; ObjectID = "Oyz-dy-DGm"; */
+"Oyz-dy-DGm.title" = "Parar de Falar";
+
+/* Class = "NSMenuItem"; title = "Bigger"; ObjectID = "Ptp-SP-VEL"; */
+"Ptp-SP-VEL.title" = "Aumentar";
+
+/* Class = "NSMenuItem"; title = "Show Fonts"; ObjectID = "Q5e-8K-NDq"; */
+"Q5e-8K-NDq.title" = "Mostrar Fontes";
+
+/* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "R4o-n2-Eq4"; */
+"R4o-n2-Eq4.title" = "Zoom";
+
+/* Class = "NSMenuItem"; title = "\tRight to Left"; ObjectID = "RB4-Sm-HuC"; */
+"RB4-Sm-HuC.title" = "\tDireita Para Esquerda";
+
+/* Class = "NSMenuItem"; title = "Superscript"; ObjectID = "Rqc-34-cIF"; */
+"Rqc-34-cIF.title" = "Superescrito";
+
+/* Class = "NSMenuItem"; title = "Select All"; ObjectID = "Ruw-6m-B2m"; */
+"Ruw-6m-B2m.title" = "Selecionar Tudo";
+
+/* Class = "NSMenuItem"; title = "Jump to Selection"; ObjectID = "S0p-oC-mLd"; */
+"S0p-oC-mLd.title" = "Pular Para a Seleção";
+
+/* Class = "NSMenu"; title = "Window"; ObjectID = "Td7-aD-5lo"; */
+"Td7-aD-5lo.title" = "Janela";
+
+/* Class = "NSMenuItem"; title = "Capitalize"; ObjectID = "UEZ-Bs-lqG"; */
+"UEZ-Bs-lqG.title" = "Capitalizar";
+
+/* Class = "NSMenuItem"; title = "Center"; ObjectID = "VIY-Ag-zcb"; */
+"VIY-Ag-zcb.title" = "Centralizar";
+
+/* Class = "NSMenuItem"; title = "Hide Others"; ObjectID = "Vdr-fp-XzO"; */
+"Vdr-fp-XzO.title" = "Esconder Outros";
+
+/* Class = "NSMenuItem"; title = "Italic"; ObjectID = "Vjx-xi-njq"; */
+"Vjx-xi-njq.title" = "Itálico";
+
+/* Class = "NSMenu"; title = "Edit"; ObjectID = "W48-6f-4Dl"; */
+"W48-6f-4Dl.title" = "Editar";
+
+/* Class = "NSMenuItem"; title = "Underline"; ObjectID = "WRG-CD-K1S"; */
+"WRG-CD-K1S.title" = "Sublinhado";
+
+/* Class = "NSMenuItem"; title = "New"; ObjectID = "Was-JA-tGl"; */
+"Was-JA-tGl.title" = "Novo";
+
+/* Class = "NSMenuItem"; title = "Paste and Match Style"; ObjectID = "WeT-3V-zwk"; */
+"WeT-3V-zwk.title" = "Colar e Manter Estilo";
+
+/* Class = "NSMenuItem"; title = "Find…"; ObjectID = "Xz5-n4-O0W"; */
+"Xz5-n4-O0W.title" = "Procurar...";
+
+/* Class = "NSMenuItem"; title = "Find and Replace…"; ObjectID = "YEy-JH-Tfz"; */
+"YEy-JH-Tfz.title" = "Procurar e Substituir...";
+
+/* Class = "NSMenuItem"; title = "\tDefault"; ObjectID = "YGs-j5-SAR"; */
+"YGs-j5-SAR.title" = "\tPadrão";
+
+/* Class = "NSMenuItem"; title = "Start Speaking"; ObjectID = "Ynk-f8-cLZ"; */
+"Ynk-f8-cLZ.title" = "Começar a Falar";
+
+/* Class = "NSMenuItem"; title = "Align Left"; ObjectID = "ZM1-6Q-yy1"; */
+"ZM1-6Q-yy1.title" = "Alinhar à Esquerda";
+
+/* Class = "NSMenuItem"; title = "Paragraph"; ObjectID = "ZvO-Gk-QUH"; */
+"ZvO-Gk-QUH.title" = "Parágrafo";
+
+/* Class = "NSMenuItem"; title = "Print…"; ObjectID = "aTl-1u-JFS"; */
+"aTl-1u-JFS.title" = "Imprimir...";
+
+/* Class = "NSMenuItem"; title = "Window"; ObjectID = "aUF-d1-5bR"; */
+"aUF-d1-5bR.title" = "Janela";
+
+/* Class = "NSMenu"; title = "Font"; ObjectID = "aXa-aM-Jaq"; */
+"aXa-aM-Jaq.title" = "Fonte";
+
+/* Class = "NSMenuItem"; title = "Use Default"; ObjectID = "agt-UL-0e3"; */
+"agt-UL-0e3.title" = "Usar Padrão";
+
+/* Class = "NSMenuItem"; title = "Show Colors"; ObjectID = "bgn-CT-cEk"; */
+"bgn-CT-cEk.title" = "Mostrar Cores";
+
+/* Class = "NSMenu"; title = "File"; ObjectID = "bib-Uj-vzu"; */
+"bib-Uj-vzu.title" = "Arquivo";
+
+/* Class = "NSMenuItem"; title = "Use Selection for Find"; ObjectID = "buJ-ug-pKt"; */
+"buJ-ug-pKt.title" = "Usar Seleção Para Procurar";
+
+/* Class = "NSMenu"; title = "Transformations"; ObjectID = "c8a-y6-VQd"; */
+"c8a-y6-VQd.title" = "Transformações";
+
+/* Class = "NSMenuItem"; title = "Use None"; ObjectID = "cDB-IK-hbR"; */
+"cDB-IK-hbR.title" = "Não Usar Nenhum";
+
+/* Class = "NSMenuItem"; title = "Selection"; ObjectID = "cqv-fj-IhA"; */
+"cqv-fj-IhA.title" = "Seleção";
+
+/* Class = "NSMenuItem"; title = "Smart Links"; ObjectID = "cwL-P1-jid"; */
+"cwL-P1-jid.title" = "Links Inteligentes";
+
+/* Class = "NSMenuItem"; title = "Make Lower Case"; ObjectID = "d9M-CD-aMd"; */
+"d9M-CD-aMd.title" = "Tornar Minúsculo";
+
+/* Class = "NSMenu"; title = "Text"; ObjectID = "d9c-me-L2H"; */
+"d9c-me-L2H.title" = "Texto";
+
+/* Class = "NSMenuItem"; title = "File"; ObjectID = "dMs-cI-mzQ"; */
+"dMs-cI-mzQ.title" = "Arquivo";
+
+/* Class = "NSMenuItem"; title = "Undo"; ObjectID = "dRJ-4n-Yzg"; */
+"dRJ-4n-Yzg.title" = "Desfazer";
+
+/* Class = "NSMenuItem"; title = "Paste"; ObjectID = "gVA-U4-sdL"; */
+"gVA-U4-sdL.title" = "Colar";
+
+/* Class = "NSMenuItem"; title = "Smart Quotes"; ObjectID = "hQb-2v-fYv"; */
+"hQb-2v-fYv.title" = "Citações Inteligentes";
+
+/* Class = "NSMenuItem"; title = "Check Document Now"; ObjectID = "hz2-CU-CR7"; */
+"hz2-CU-CR7.title" = "Checar Documento Agora";
+
+/* Class = "NSMenu"; title = "Services"; ObjectID = "hz9-B4-Xy5"; */
+"hz9-B4-Xy5.title" = "Serviços";
+
+/* Class = "NSMenuItem"; title = "Smaller"; ObjectID = "i1d-Er-qST"; */
+"i1d-Er-qST.title" = "Diminuir";
+
+/* Class = "NSMenu"; title = "Baseline"; ObjectID = "ijk-EB-dga"; */
+"ijk-EB-dga.title" = "Linha de Base";
+
+/* Class = "NSMenuItem"; title = "Kern"; ObjectID = "jBQ-r6-VK2"; */
+"jBQ-r6-VK2.title" = "Kern";
+
+/* Class = "NSMenuItem"; title = "\tRight to Left"; ObjectID = "jFq-tB-4Kx"; */
+"jFq-tB-4Kx.title" = "\tDireita Para Esquerda";
+
+/* Class = "NSMenuItem"; title = "Format"; ObjectID = "jxT-CU-nIS"; */
+"jxT-CU-nIS.title" = "Formatar";
+
+/* Class = "NSMenuItem"; title = "Show Sidebar"; ObjectID = "kIP-vf-haE"; */
+"kIP-vf-haE.title" = "Mostrar Barra Lateral";
+
+/* Class = "NSMenuItem"; title = "Check Grammar With Spelling"; ObjectID = "mK6-2p-4JG"; */
+"mK6-2p-4JG.title" = "Checar Gramática Com Ortografia";
+
+/* Class = "NSMenuItem"; title = "Ligatures"; ObjectID = "o6e-r0-MWq"; */
+"o6e-r0-MWq.title" = "Ligações";
+
+/* Class = "NSMenu"; title = "Open Recent"; ObjectID = "oas-Oc-fiZ"; */
+"oas-Oc-fiZ.title" = "Abrir Recente";
+
+/* Class = "NSMenuItem"; title = "Loosen"; ObjectID = "ogc-rX-tC1"; */
+"ogc-rX-tC1.title" = "Soltar";
+
+/* Class = "NSMenuItem"; title = "Delete"; ObjectID = "pa3-QI-u2k"; */
+"pa3-QI-u2k.title" = "Deletar";
+
+/* Class = "NSMenuItem"; title = "Save…"; ObjectID = "pxx-59-PXV"; */
+"pxx-59-PXV.title" = "Salvar...";
+
+/* Class = "NSMenuItem"; title = "Find Next"; ObjectID = "q09-fT-Sye"; */
+"q09-fT-Sye.title" = "Encontrar Próximo";
+
+/* Class = "NSMenuItem"; title = "Page Setup…"; ObjectID = "qIS-W8-SiK"; */
+"qIS-W8-SiK.title" = "Configuração da Página...";
+
+/* Class = "NSMenuItem"; title = "Check Spelling While Typing"; ObjectID = "rbD-Rh-wIN"; */
+"rbD-Rh-wIN.title" = "Checar Ortografia Enquanto Digita";
+
+/* Class = "NSMenuItem"; title = "Smart Dashes"; ObjectID = "rgM-f4-ycn"; */
+"rgM-f4-ycn.title" = "Traços Inteligentes";
+
+/* Class = "NSMenuItem"; title = "Show Toolbar"; ObjectID = "snW-S8-Cw5"; */
+"snW-S8-Cw5.title" = "Mostrar Barra de Ferramentas";
+
+/* Class = "NSMenuItem"; title = "Data Detectors"; ObjectID = "tRr-pd-1PS"; */
+"tRr-pd-1PS.title" = "Detectores de Dados";
+
+/* Class = "NSMenuItem"; title = "Open Recent"; ObjectID = "tXI-mr-wws"; */
+"tXI-mr-wws.title" = "Abrir Recente";
+
+/* Class = "NSMenu"; title = "Kern"; ObjectID = "tlD-Oa-oAM"; */
+"tlD-Oa-oAM.title" = "Kern";
+
+/* Class = "NSMenu"; title = "DevToys"; ObjectID = "uQy-DD-JDr"; */
+"uQy-DD-JDr.title" = "DevToys";
+
+/* Class = "NSMenuItem"; title = "Cut"; ObjectID = "uRl-iY-unG"; */
+"uRl-iY-unG.title" = "Cortar";
+
+/* Class = "NSMenuItem"; title = "Paste Style"; ObjectID = "vKC-jM-MkH"; */
+"vKC-jM-MkH.title" = "Colar Estilo";
+
+/* Class = "NSMenuItem"; title = "Show Ruler"; ObjectID = "vLm-3I-IUL"; */
+"vLm-3I-IUL.title" = "Mostrar Régua";
+
+/* Class = "NSMenuItem"; title = "Clear Menu"; ObjectID = "vNY-rz-j42"; */
+"vNY-rz-j42.title" = "Limpar Menu";
+
+/* Class = "NSMenuItem"; title = "Make Upper Case"; ObjectID = "vmV-6d-7jI"; */
+"vmV-6d-7jI.title" = "Tornar Maiúsculo";
+
+/* Class = "NSMenu"; title = "Ligatures"; ObjectID = "w0m-vy-SC9"; */
+"w0m-vy-SC9.title" = "Ligações";
+
+/* Class = "NSMenuItem"; title = "Align Right"; ObjectID = "wb2-vD-lq4"; */
+"wb2-vD-lq4.title" = "Alinhar à Direita";
+
+/* Class = "NSMenuItem"; title = "Help"; ObjectID = "wpr-3q-Mcd"; */
+"wpr-3q-Mcd.title" = "Ajuda";
+
+/* Class = "NSMenuItem"; title = "Copy"; ObjectID = "x3v-GG-iWU"; */
+"x3v-GG-iWU.title" = "Copiar";
+
+/* Class = "NSMenuItem"; title = "Use All"; ObjectID = "xQD-1f-W4t"; */
+"xQD-1f-W4t.title" = "Usar Todos";
+
+/* Class = "NSMenuItem"; title = "Speech"; ObjectID = "xrE-MZ-jX0"; */
+"xrE-MZ-jX0.title" = "Fala";
+
+/* Class = "NSMenuItem"; title = "Show Substitutions"; ObjectID = "z6F-FW-3nz"; */
+"z6F-FW-3nz.title" = "Mostrar Substituições";


### PR DESCRIPTION
This PR translates both `Localizable.strings` and `Main.strings` to Brazilian Portuguese.

Evidences:

<img width="1271" alt="image" src="https://user-images.githubusercontent.com/28109145/153847261-d1049a2f-744b-488c-981e-0ac5e6efeb00.png">

**Note:** Unfortunately the description for both URL and HTML decoder/encoder ended up a little bigger than the card. Is there something I can do about it?

![Kapture 2022-02-14 at 07 31 52](https://user-images.githubusercontent.com/28109145/153847586-5702442a-932c-46f3-98c1-0e434e21fd0b.gif)


This is my first time ever contributing to a project written in Swift, so if anything's wrong please tell me :)