### PR TITLE
Update install notes to include Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is the mac app version of [DevToys](https://github.com/veler/DevToys)!
 - Extract `DevToys.app` from `DevToys.app.zip`
 
 ## Homebrew
-- Install [Homebrew](https://brew.sh/). Then install DevToysMac with `brew install devtoys`.
+- Install [Homebrew](https://brew.sh/). Then install DevToysMac with `brew install --cask devtoys`.
 
 # Screenshots
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@ This is the mac app version of [DevToys](https://github.com/veler/DevToys)!
 
 # How to install
 
-- Download and extract the latest [Releases](https://github.com/ObuchiYuki/DevToysMac/releases).
-- Extract `DevToys.app` from `DevToys.zip`
+## Manually
+- Download the [latest release](https://github.com/ObuchiYuki/DevToysMac/releases/latest).
+- Extract `DevToys.app` from `DevToys.app.zip`
+
+## Homebrew
+- Install [Homebrew](https://brew.sh/). Then install DevToysMac with `brew install devtoys`.
 
 # Screenshots
 


### PR DESCRIPTION
This tweaks the notes on manual installation and also adds installation via [Homebrew](https://brew.sh) as option.