### PR TITLE
fix: base64 decode

### DIFF
--- a/DevToys/DevToys/Body/Coder/Base64DecoderView+.swift
+++ b/DevToys/DevToys/Body/Coder/Base64DecoderView+.swift
@@ -19,7 +19,7 @@ final class Base64DecoderViewController: NSViewController {
     override func viewDidLoad() {
         self.cell.inputTextSection.stringPublisher
             .sink{[unowned self] in self.rawString = $0; self.formattedString = encode($0) }.store(in: &objectBag)
-        self.cell.inputTextSection.stringPublisher
+        self.cell.encodeTextSection.stringPublisher
             .sink{[unowned self] in self.formattedString = $0; self.rawString = decode($0) }.store(in: &objectBag)
         self.cell.sourceTypePicker.itemPublisher
             .sink{[unowned self] in self.sourceType = $0 }.store(in: &objectBag)


### PR DESCRIPTION
fixed: base64 decode feature was not working
Probably an omission of correction 3e2d31d1611ed064b0f8ec3ba542f1f9dce464a6

いつもありがとうございます。大変便利に活用させていただいています。