### PR TITLE
Fix some irregular localization words for zh-Hans

### DIFF
--- a/DevToys/DevToys/Resource/zh-Hans.lproj/Localizable.strings
+++ b/DevToys/DevToys/Resource/zh-Hans.lproj/Localizable.strings
@@ -16,9 +16,9 @@
 "File" = "文件";
 "Text" = "文本";
 "Copy" = "复制";
-"Paste" = "黏贴";
-"Copied!" = "复制!";
-"Pasted!" = "黏贴!";
+"Paste" = "粘贴";
+"Copied!" = "已复制!";
+"Pasted!" = "已粘贴!";
 "Open" = "打开";
 "Export" = "导出";
 "Import" = "导入";


### PR DESCRIPTION
It is very rare to see `黏贴` as the translation to `Paste`. Usually, on both macOS and Windows, we use the word `粘贴`.

Ref 1: DevToy Windows

https://github.com/veler/DevToys/blob/507e11018e9a444da549fc6244269602e0deea0b/src/dev/impl/DevToys/Strings/zh-Hans/Common.resw#L189C1-L190

Ref 2: Example in macOS Finder.app:

![截屏2023-12-18 11 46 06](https://github.com/ObuchiYuki/DevToysMac/assets/1019875/61bace86-d9d3-45a4-a591-e9d49c49a831)

Also, I updated the translation for the past tense words of `Copied` and `Pasted` to reflect it.
